### PR TITLE
Update AWS region configuration and add CSS for delete search view

### DIFF
--- a/assets/components.js
+++ b/assets/components.js
@@ -11,7 +11,7 @@ export const __dirname = path.dirname(__filename);
 config({ path: path.join(__dirname, '../.env') });
 
 export const s3Client = new S3Client({
-    region: process.env.AWS_REGION || 'us-east-1',
+    region: process.env.AWS_REGION,
     credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY

--- a/views/deleteSearch.ejs
+++ b/views/deleteSearch.ejs
@@ -18,6 +18,7 @@
     <title>TempFile • Delete</title>
     <%- include('include/head.ejs') %> 
     <link rel="icon" href="/media/favicon.ico">
+    <link rel="stylesheet" href="/css/deleteSearch.css">
     <script src="/js/deleteSearch.js"></script>
 </head>
 


### PR DESCRIPTION
## Summary by Sourcery

Update AWS S3 client region configuration to require an explicit AWS_REGION env var and add CSS styling to the delete search page

New Features:
- Include deleteSearch.css stylesheet in the delete search view

Enhancements:
- Remove default 'us-east-1' region fallback in S3 client configuration to rely solely on AWS_REGION environment variable